### PR TITLE
Feature: Add NPM post-install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,32 @@
-
 # Flattiance
+> A semi-flat fork of the Ubuntu Ambiance theme.
 
  [![Support me on Patreon][badge_patreon]][patreon] [![Buy me a book][badge_amazon]][amazon] [![PayPal][badge_paypal_donate]][paypal-donations] [![Version](https://img.shields.io/npm/v/flattiance.svg)](https://www.npmjs.com/package/flattiance) [![Downloads](https://img.shields.io/npm/dt/flattiance.svg)](https://www.npmjs.com/package/flattiance)
 
-> A semi-flat fork of the Ubuntu Ambiance theme.
+
+[![flattiance](http://i.imgur.com/rt7GEIL.png)](#)
 
 ## Installation
 
-Copy the `Flattiance` directory into `/usr/share/themes/` and activate it using `unity-tweak-tool`.
+### npm
 
+```sh
+npm install --global flattiance
+```
 
-[![flattiance](http://i.imgur.com/rt7GEIL.png)](#)
+That's it. Skip to [Getting Started](#getting-started)
+
+### Manual
+
+1. Clone this repo: `git clone https://github.com/IonicaBizau/Flattiance.git`
+1. Copy the `Flattiance` sub-directory into `/usr/share/themes/` (for all users): `[sudo] cp -r Flattiance/Flattiance /usr/share/themes`
+    - Or copy to `$HOME/.themes` (for local user): `cp -r Flattiance/Flattiance $HOME/.themes`
+
+## Getting Started
+
+Activate the theme via `unity-tweak-tool`:
+- Click `Theme`
+- Select `Flattiance`
 
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A semi-flat fork of the Ubuntu Ambiance theme.",
   "main": "lib/index.js",
   "scripts": {
-    "postinstall": "npm run postinstall:create-themes-dir && npm run postinstall:copy-theme",
+    "postinstall": "npm run postinstall:create-themes-dir && npm run postinstall:copy-theme && npm run postinstall:start-unity-tweak-tool",
     "postinstall:create-themes-dir": "mkdir -p $HOME/.themes",
     "postinstall:copy-theme": "cp -r Flattiance $HOME/.themes",
     "postinstall:start-unity-tweak-tool": "if type unity-tweak-tool > /dev/null; then unity-tweak-tool -a; else echo 'Please, install unity-tweak-tool and manually activate Flattiance theme'; fi"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A semi-flat fork of the Ubuntu Ambiance theme.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "npm run postinstall:create-themes-dir && npm run postinstall:copy-theme",
+    "postinstall:create-themes-dir": "mkdir -p $HOME/.themes",
+    "postinstall:copy-theme": "cp -r Flattiance $HOME/.themes"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "postinstall": "npm run postinstall:create-themes-dir && npm run postinstall:copy-theme",
     "postinstall:create-themes-dir": "mkdir -p $HOME/.themes",
-    "postinstall:copy-theme": "cp -r Flattiance $HOME/.themes"
+    "postinstall:copy-theme": "cp -r Flattiance $HOME/.themes",
+    "postinstall:start-unity-tweak-tool": "if type unity-tweak-tool > /dev/null; then unity-tweak-tool -a; else echo 'Please, install unity-tweak-tool and manually activate Flattiance theme'; fi"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi @IonicaBizau ,

Thank you for this lovely theme.
I contributed a feature that I hope you find helpful/useful.

I have added npm scripts that automatically get executed after the user installs the theme via npm.
Once the user types: `npm install --global flattiance`, npm will:
- create a local `.themes` directory in the current user's `$HOME` directory
- copy the `Flattiance` sub-directory into `$HOME/.themes`

I have also updated the README accordingly to inform users of the two current options for installing this theme.

I hope you find this Pull-Request beneficial.
If not, feel free to close it.

Let me know if you have any questions.

Thank you.